### PR TITLE
Make sure to hide all backgrounds upon completion of the animations

### DIFF
--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
@@ -296,11 +296,17 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
 
                 if (mDownView != null && mSwiping) {
                     // cancel
+                    final int downPosition = mDownPosition;
                     mDownView.animate()
                             .translationX(0)
                             .alpha(1)
                             .setDuration(mAnimationTime)
-                            .setListener(null);
+                            .setListener(new AnimatorListenerAdapter() {
+                                @Override
+                                public void onAnimationEnd(Animator animation) {
+                                    resetBackgrounds(downPosition);
+                                }
+                            });
                 }
                 mVelocityTracker.recycle();
                 mVelocityTracker = null;
@@ -360,11 +366,17 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                             });
                 } else {
                     // cancel
+                    final int downPosition = mDownPosition;
                     mDownView.animate()
                             .translationX(0)
                             .alpha(1)
                             .setDuration(mAnimationTime)
-                            .setListener(null);
+                            .setListener(new AnimatorListenerAdapter() {
+                                @Override
+                                public void onAnimationEnd(Animator animation) {
+                                    resetBackgrounds(downPosition);
+                                }
+                            });
                 }
                 mVelocityTracker.recycle();
                 mVelocityTracker = null;
@@ -417,6 +429,16 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
             }
         }
         return false;
+    }
+
+    private void resetBackgrounds(int position) {
+        int firstVisiblePosition = mListView.getFirstVisiblePosition();
+        int lastVisiblePosition = mListView.getLastVisiblePosition();
+        if (position >= firstVisiblePosition && position <= lastVisiblePosition) {
+            // We need to prevent the swipe background from showing through once swipe is complete
+            SwipeViewGroup swipeViewGroup = (SwipeViewGroup) mListView.getChildAt(position - firstVisiblePosition);
+            swipeViewGroup.hideBackgrounds();
+        }
     }
 
     class PendingDismissData implements Comparable<PendingDismissData> {
@@ -510,6 +532,9 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                     mListView.dispatchTouchEvent(cancelEvent);
 
                     mPendingDismisses.clear();
+                    for (int position: dismissPositions) {
+                        resetBackgrounds(position);
+                    }
                 }
             }
         };

--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeViewGroup.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeViewGroup.java
@@ -24,6 +24,8 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import java.util.List;
+
 /**
  * Class to hold a ListView item and the swipe backgrounds
  *
@@ -109,6 +111,18 @@ public class SwipeViewGroup extends FrameLayout {
         mBackgroundMap.get(direction).setVisibility(View.VISIBLE);
         mBackgroundMap.get(direction).setAlpha(dimBackground ? 0.4f : 1);
         visibleView = direction;
+    }
+
+    /**
+     * Hide all of the directional backgrounds
+     *
+     */
+    public void hideBackgrounds() {
+        List<Integer> directions = SwipeDirections.getAllDirections();
+        for (int direction: directions) {
+            View view = mBackgroundMap.get(direction);
+            if (view != null) view.setVisibility(INVISIBLE);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed backgrounds mode does not make the directional views invisible upon the completion of the animation, causing incorrect rendering. This patch addresses the issue.
![screenshot 11_41am may 13 2015](https://cloud.githubusercontent.com/assets/1417338/7618299/1367aec2-f966-11e4-86bc-98eb24789b3a.png)
