### PR TITLE
Fixed bug with different row heights

### DIFF
--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionAdapter.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionAdapter.java
@@ -174,6 +174,17 @@ public class SwipeActionAdapter extends DecoratorAdapter implements
     }
 
     /**
+     * Enable a swipe direction (none are enabled by default)
+     * Automatically adds on addBackground
+     *
+     * @param direction Integer const from SwipeDirections
+     */
+    public SwipeActionAdapter addEnabledDirection(Integer direction) {
+        mTouchListener.addEnabledDirection(direction);
+        return this;
+    }
+    
+    /**
      * We need the ListView to be able to modify it's OnTouchListener
      *
      * @param listView the ListView to which the adapter will be attached
@@ -212,7 +223,10 @@ public class SwipeActionAdapter extends DecoratorAdapter implements
      * @return A reference to the current instance so that commands can be chained
      */
     public SwipeActionAdapter addBackground(int key, int resId){
-        if(SwipeDirections.getAllDirections().contains(key)) mBackgroundResIds.put(key,resId);
+        if(SwipeDirections.getAllDirections().contains(key)) {
+            mBackgroundResIds.put(key,resId);
+            addEnabledDirection(key);
+        }
         return this;
     }
 

--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
@@ -101,6 +101,7 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
     private boolean mPaused;
     private int mDirection;
     private boolean mFar;
+    private List<Integer> mEnabledDirections = new ArrayList<>();
 
     /**
      * The callback interface used by {@link SwipeActionTouchListener} to inform its client
@@ -237,6 +238,16 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
         mNormalSwipeFraction = normalSwipeFraction;
     }
 
+    /**
+     * Enable a swipe direction (none are enabled by default)
+     *
+     * @param direction Integer const from SwipeDirections
+     */
+    protected void addEnabledDirection(Integer direction) {
+        if(!this.mEnabledDirections.contains(direction))
+            this.mEnabledDirections.add(direction);
+    }
+    
     @Override
     public boolean onTouch(View view, MotionEvent motionEvent) {
         if (mViewWidth < 2) {
@@ -332,14 +343,16 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                 float absVelocityY = Math.abs(mVelocityTracker.getYVelocity());
                 boolean dismiss = false;
                 boolean dismissRight = false;
-                if (Math.abs(deltaX) > (mViewWidth * mNormalSwipeFraction) && mSwiping) {
-                    dismiss = true;
-                    dismissRight = deltaX > 0;
-                } else if (mMinFlingVelocity <= absVelocityX && absVelocityX <= mMaxFlingVelocity
-                        && absVelocityY < absVelocityX && mSwiping) {
-                    // dismiss only if flinging in the same direction as dragging
-                    dismiss = (velocityX < 0) == (deltaX < 0);
-                    dismissRight = mVelocityTracker.getXVelocity() > 0;
+                if(mEnabledDirections.contains(mDirection)) {
+                    if (Math.abs(deltaX) > (mViewWidth * mNormalSwipeFraction) && mSwiping) {
+                        dismiss = true;
+                        dismissRight = deltaX > 0;
+                    } else if (mMinFlingVelocity <= absVelocityX && absVelocityX <= mMaxFlingVelocity
+                            && absVelocityY < absVelocityX && mSwiping) {
+                        // dismiss only if flinging in the same direction as dragging
+                        dismiss = (velocityX < 0) == (deltaX < 0);
+                        dismissRight = mVelocityTracker.getXVelocity() > 0;
+                    }
                 }
                 if (dismiss && mDownPosition != ListView.INVALID_POSITION) {
                     // dismiss
@@ -416,12 +429,13 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                     if(!mFar && Math.abs(deltaX) > mViewWidth*mFarSwipeFraction) mFar = true;
                     if(!mFar) mDirection = (deltaX > 0 ? SwipeDirections.DIRECTION_NORMAL_RIGHT : SwipeDirections.DIRECTION_NORMAL_LEFT);
                     else mDirection = (deltaX > 0 ? SwipeDirections.DIRECTION_FAR_RIGHT : SwipeDirections.DIRECTION_FAR_LEFT);
-                    mDownViewGroup.showBackground(mDirection, mDimBackgrounds && (Math.abs(deltaX) < mViewWidth*mNormalSwipeFraction));
-
-                    mDownView.setTranslationX(deltaX - mSwipingSlop);
-                    if(mFadeOut) mDownView.setAlpha(Math.max(0f, Math.min(1f,
-                                1f - 2f * Math.abs(deltaX) / mViewWidth)));
-                    return true;
+                    if(mEnabledDirections.contains(mDirection)) {
+                        mDownViewGroup.showBackground(mDirection, mDimBackgrounds && (Math.abs(deltaX) < mViewWidth*mNormalSwipeFraction));
+                        mDownView.setTranslationX(deltaX - mSwipingSlop);
+                        if(mFadeOut) mDownView.setAlpha(Math.max(0f, Math.min(1f,
+                                    1f - 2f * Math.abs(deltaX) / mViewWidth)));
+                        return true;
+                    }
                 }
                 break;
             }

--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
@@ -448,13 +448,13 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
     }
 
     private void slideBack(final View slideInView, final int downPosition, final int direction){
-        mPendingDismisses.add(new PendingDismissData(downPosition,direction,slideInView));
+        mPendingDismisses.add(new PendingDismissData(downPosition, direction, slideInView));
         slideInView.setTranslationX(slideInView.getTranslationX());
         slideInView.animate()
                 .translationX(0)
                 .alpha(1)
                 .setDuration(mAnimationTime)
-                .setListener(createAnimatorListener(slideInView.getHeight()));
+                .setListener(createAnimatorListener());
     }
 
     private void performDismiss(final View dismissView, final int dismissPosition, final int direction) {
@@ -467,7 +467,7 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
 
         ValueAnimator animator = ValueAnimator.ofInt(originalHeight, 1).setDuration(mAnimationTime);
 
-        animator.addListener(createAnimatorListener(originalHeight));
+        animator.addListener(createAnimatorListener());
 
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
@@ -481,7 +481,7 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
         animator.start();
     }
 
-    private AnimatorListenerAdapter createAnimatorListener(final int originalHeight){
+    private AnimatorListenerAdapter createAnimatorListener(){
         return new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(Animator animation) {
@@ -503,14 +503,12 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                     // animation with a stale position
                     mDownPosition = ListView.INVALID_POSITION;
 
-                    ViewGroup.LayoutParams lp;
+                    
                     for (PendingDismissData pendingDismiss : mPendingDismisses) {
                         // Reset view presentation
                         pendingDismiss.view.setAlpha(1f);
                         pendingDismiss.view.setTranslationX(0);
-                        lp = pendingDismiss.view.getLayoutParams();
-                        lp.height = originalHeight;
-                        pendingDismiss.view.setLayoutParams(lp);
+                        pendingDismiss.view.setLayoutParams(new AbsListView.LayoutParams(AbsListView.LayoutParams.MATCH_PARENT, AbsListView.LayoutParams.WRAP_CONTENT));
                     }
 
                     // Send a cancel event


### PR DESCRIPTION
- Fixed bug with different row heights
When an item is deleted, it's view is being shrink and them the list is refreshed with the new data.
When the view is recycled it needs to be reseted to the right size.
It is now set to WRAP_CONTENT to match the content row size.
- Added enabling/disabling of swipe directions