### PR TITLE
Implemented onSwipeStarted and onSwipeEnded

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ protected void onCreate(Bundle savedInstanceState) {
                 mAdapter.notifyDataSetChanged();
             }
         }
+        
+        @Override
+        public void onSwipeStarted(ListView listView, int position, SwipeDirection direction) {
+            // User is swiping
+        }
+        
+        @Override
+        public void onSwipeEnded(ListView listView, int position, SwipeDirection direction) {
+            // User stopped swiping (lifted finger from the screen)
+        }
     });
 }
 ```
@@ -243,6 +253,18 @@ Allows you to set the fraction of the view width that must be swiped before it i
 Allows you to set the fraction of the view width that must be swiped before it is counted as a far swipe. The float must be between 0 and 1. 0 makes every swipe a far swipe, 1 effectively disables a far swipe.
 
 
+### onSwipeStarted and onSwipeEnded
+You can use these events to execute code once the user starts or stops swiping in a listItem. This can be used to fix issues 
+relating to other libraries hijacking touch events (for example; a SwipeRefreshLayout).
+```
+@Override
+public void onSwipeStarted(ListView listView, int position, SwipeDirection direction) {
+}
+
+@Override
+public void onSwipeEnded(ListView listView, int position, SwipeDirection direction) {
+}
+```
 License
 =======
 

--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionAdapter.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionAdapter.java
@@ -108,6 +108,32 @@ public class SwipeActionAdapter extends DecoratorAdapter implements
     }
 
     /**
+     * Called once the user touches the screen and starts swiping in any direction
+     *
+     * @param listView  The originating {@link ListView}.
+     * @param position  The position to perform the action on, sorted in descending  order
+     *                  for convenience.
+     * @param direction The type of swipe that triggered the action
+     */
+    @Override
+    public void onSwipeStarted(ListView listView, int position, SwipeDirection direction) {
+        if(mSwipeActionListener != null) mSwipeActionListener.onSwipeStarted(listView, position, direction);
+    }
+
+    /**
+     * Called once the swiping motion ended (user lifted finger)
+     *
+     * @param listView  The originating {@link ListView}.
+     * @param position  The position to perform the action on, sorted in descending  order
+     *                  for convenience.
+     * @param direction The type of swipe that triggered the action
+     */
+    @Override
+    public void onSwipeEnded(ListView listView, int position, SwipeDirection direction) {
+        if(mSwipeActionListener != null) mSwipeActionListener.onSwipeEnded(listView, position, direction);
+    }
+
+    /**
      * Set whether items should have a fadeOut animation
      *
      * @param mFadeOut true makes items fade out with a swipe (opacity -> 0)
@@ -175,7 +201,7 @@ public class SwipeActionAdapter extends DecoratorAdapter implements
         if(mListView != null) mTouchListener.setNormalSwipeFraction(normalSwipeFraction);
         return this;
     }
-    
+
     /**
      * We need the ListView to be able to modify it's OnTouchListener
      *
@@ -237,5 +263,7 @@ public class SwipeActionAdapter extends DecoratorAdapter implements
         boolean hasActions(int position, SwipeDirection direction);
         boolean shouldDismiss(int position, SwipeDirection direction);
         void onSwipe(int[] position, SwipeDirection[] direction);
+        void onSwipeStarted(ListView listView, int position, SwipeDirection direction);
+        void onSwipeEnded(ListView listView, int position, SwipeDirection direction);
     }
 }

--- a/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
+++ b/library/src/main/java/com/wdullaer/swipeactionadapter/SwipeActionTouchListener.java
@@ -139,6 +139,24 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
          * @param direction The type of swipe that triggered the action
          */
         void onAction(ListView listView, int[] position, SwipeDirection[] direction);
+
+        /**
+         * Called once the user touches the screen and starts swiping in any direction
+         *
+         * @param listView The originating {@link ListView}.
+         * @param position The position the user is swiping at
+         * @param direction The type of swipe that triggered the action
+         */
+        void onSwipeStarted(ListView listView, int position, SwipeDirection direction);
+
+        /**
+         * Called once the swiping motion ended (user lifted finger from the screen)
+         *
+         * @param listView The originating {@link ListView}.
+         * @param position The position started swiping on
+         * @param direction The type of swipe that triggered the action
+         */
+        void onSwipeEnded(ListView listView, int position, SwipeDirection direction);
     }
 
     /**
@@ -320,7 +338,7 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                 if (mVelocityTracker == null) {
                     break;
                 }
-
+                mCallbacks.onSwipeEnded(mListView, mDownPosition, mDirection);
                 float deltaX = motionEvent.getRawX() - mDownX;
                 mVelocityTracker.addMovement(motionEvent);
                 mVelocityTracker.computeCurrentVelocity(1000);
@@ -411,6 +429,7 @@ public class SwipeActionTouchListener implements View.OnTouchListener {
                 }
 
                 if (mSwiping) {
+                    mCallbacks.onSwipeStarted(mListView, mDownPosition, mDirection);
                     if(mDirection.isLeft() && deltaX > 0 || mDirection.isRight() && deltaX < 0) mFar = false;
                     if(!mFar && Math.abs(deltaX) > mViewWidth*mFarSwipeFraction) mFar = true;
                     if(!mFar) mDirection = (deltaX > 0 ? SwipeDirection.DIRECTION_NORMAL_RIGHT : SwipeDirection.DIRECTION_NORMAL_LEFT);


### PR DESCRIPTION
This fixed the issue described in "SwipeRefreshLayout touch events collide with SwipeActionAdapter" by exposing two new events (OnSwipeStarted and OnSwipeEnded).

Fixes #59 